### PR TITLE
DDP bug fix

### DIFF
--- a/run/Train.py
+++ b/run/Train.py
@@ -35,7 +35,7 @@ def train(opt, args):
         tfs=opt.Train.Dataset.transforms)
 
     if args.device_num > 1:
-        cuda.set_device(args.device_id)
+        cuda.set_device(args.local_rank)
         dist.init_process_group(backend='nccl', rank=args.local_rank, world_size=args.device_num)
         train_sampler = DistributedSampler(train_dataset, shuffle=True)
     else:
@@ -69,7 +69,7 @@ def train(opt, args):
     if args.device_num > 1:
         model = nn.SyncBatchNorm.convert_sync_batchnorm(model)
         model = model.cuda()
-        model = nn.parallel.DistributedDataParallel(model, device_ids=[args.device_id], find_unused_parameters=True)
+        model = nn.parallel.DistributedDataParallel(model, device_ids=[args.local_rank], find_unused_parameters=True)
     else:
         model = model.cuda()
 

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -34,7 +34,6 @@ def parse_args():
     
     cuda_visible_devices = None
     local_rank = -1
-    device_id = None
 
     if "CUDA_VISIBLE_DEVICES" in os.environ.keys():
         cuda_visible_devices = [int(i) for i in os.environ["CUDA_VISIBLE_DEVICES"].split(',')]
@@ -45,13 +44,10 @@ def parse_args():
         device_num = 1
     elif cuda_visible_devices is None:
         device_num = torch.cuda.device_count()
-        device_id = local_rank % device_num
     else:
         device_num = len(cuda_visible_devices)
-        device_id = cuda_visible_devices[local_rank]
 
     args.device_num = device_num
-    args.device_id = device_id
     args.local_rank = local_rank
 
     return args


### PR DESCRIPTION
There was a problem with using designated GPU devices by `CUDA_VISIBLE_DEVICES` environment variable. Instead of using actual device id number, we need to used `local_rank` instead, so I replaced them and removed `device_id`. Now, training with DDP works for any cases.